### PR TITLE
feat: 記事配送ワークフローと uploadFile 上書き制御を実装 (#4)

### DIFF
--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -2,6 +2,7 @@ name: 記事配送
 
 on:
   push:
+    branches: [main]
     paths:
       - 'posts/**'
       - '!posts/**/.delivery-status.json'
@@ -59,11 +60,13 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         id: detect-dispatch
         uses: actions/github-script@v7
+        env:
+          INPUT_SLUG: ${{ inputs.slug }}
         with:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const slug = '${{ inputs.slug }}';
+            const slug = process.env.INPUT_SLUG;
             const dir = path.join('posts', slug);
             if (!fs.existsSync(dir)) {
               core.setFailed(`posts/${slug} が存在しません`);
@@ -92,18 +95,24 @@ jobs:
         env:
           STORAGE_BACKEND: ${{ secrets.STORAGE_BACKEND }}
           DROPBOX_ACCESS_TOKEN: ${{ secrets.DROPBOX_ACCESS_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          PUSH_FILES: ${{ steps.detect-push.outputs.files }}
+          PUSH_COUNT: ${{ steps.detect-push.outputs.count }}
+          DISPATCH_FILES: ${{ steps.detect-dispatch.outputs.files }}
+          DISPATCH_COUNT: ${{ steps.detect-dispatch.outputs.count }}
+          INPUT_OVERWRITE: ${{ inputs.overwrite }}
         with:
           script: |
             const fs = require('fs');
 
             // 配送対象の決定
-            const isPush = '${{ github.event_name }}' === 'push';
+            const isPush = process.env.EVENT_NAME === 'push';
             const filesJson = isPush
-              ? '${{ steps.detect-push.outputs.files }}'
-              : '${{ steps.detect-dispatch.outputs.files }}';
+              ? process.env.PUSH_FILES
+              : process.env.DISPATCH_FILES;
             const count = parseInt(isPush
-              ? '${{ steps.detect-push.outputs.count }}'
-              : '${{ steps.detect-dispatch.outputs.count }}', 10);
+              ? process.env.PUSH_COUNT
+              : process.env.DISPATCH_COUNT, 10);
 
             if (count === 0) {
               core.info('配送対象ファイルなし。スキップします。');
@@ -111,8 +120,8 @@ jobs:
             }
 
             const files = JSON.parse(filesJson);
-            const overwrite = '${{ github.event_name }}' === 'workflow_dispatch'
-              && '${{ inputs.overwrite }}' === 'true';
+            const overwrite = process.env.EVENT_NAME === 'workflow_dispatch'
+              && process.env.INPUT_OVERWRITE === 'true';
 
             // StorageAdapter の生成
             const { createStorageAdapter } = await import(

--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -1,0 +1,146 @@
+name: 記事配送
+
+on:
+  push:
+    paths:
+      - 'posts/**'
+      - '!posts/**/.delivery-status.json'
+  workflow_dispatch:
+    inputs:
+      slug:
+        description: '配送対象の slug（例: my-post）'
+        required: true
+      overwrite:
+        description: '既存ファイルを上書きする'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  deliver:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: 変更ファイル検出（push）
+        if: github.event_name == 'push'
+        id: detect-push
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commits = context.payload.commits ?? [];
+            const files = new Set();
+            for (const commit of commits) {
+              for (const f of [...(commit.added ?? []), ...(commit.modified ?? [])]) {
+                if (f.startsWith('posts/') && !f.endsWith('.delivery-status.json')) {
+                  files.add(f);
+                }
+              }
+            }
+            const list = [...files];
+            core.info(`配送対象: ${list.length} ファイル`);
+            for (const f of list) core.info(`  - ${f}`);
+            core.setOutput('files', JSON.stringify(list));
+            core.setOutput('count', list.length);
+
+      - name: 配送対象ファイル列挙（workflow_dispatch）
+        if: github.event_name == 'workflow_dispatch'
+        id: detect-dispatch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const slug = '${{ inputs.slug }}';
+            const dir = path.join('posts', slug);
+            if (!fs.existsSync(dir)) {
+              core.setFailed(`posts/${slug} が存在しません`);
+              return;
+            }
+            const walk = (d) => {
+              let results = [];
+              for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+                const full = path.join(d, entry.name);
+                if (entry.isDirectory()) {
+                  results = results.concat(walk(full));
+                } else if (entry.name !== '.delivery-status.json') {
+                  results.push(full.replace(/\\/g, '/'));
+                }
+              }
+              return results;
+            };
+            const list = walk(dir);
+            core.info(`配送対象: ${list.length} ファイル`);
+            for (const f of list) core.info(`  - ${f}`);
+            core.setOutput('files', JSON.stringify(list));
+            core.setOutput('count', list.length);
+
+      - name: ファイル配送
+        uses: actions/github-script@v7
+        env:
+          STORAGE_BACKEND: ${{ secrets.STORAGE_BACKEND }}
+          DROPBOX_ACCESS_TOKEN: ${{ secrets.DROPBOX_ACCESS_TOKEN }}
+        with:
+          script: |
+            const fs = require('fs');
+
+            // 配送対象の決定
+            const isPush = '${{ github.event_name }}' === 'push';
+            const filesJson = isPush
+              ? '${{ steps.detect-push.outputs.files }}'
+              : '${{ steps.detect-dispatch.outputs.files }}';
+            const count = parseInt(isPush
+              ? '${{ steps.detect-push.outputs.count }}'
+              : '${{ steps.detect-dispatch.outputs.count }}', 10);
+
+            if (count === 0) {
+              core.info('配送対象ファイルなし。スキップします。');
+              return;
+            }
+
+            const files = JSON.parse(filesJson);
+            const overwrite = '${{ github.event_name }}' === 'workflow_dispatch'
+              && '${{ inputs.overwrite }}' === 'true';
+
+            // StorageAdapter の生成
+            const { createStorageAdapter } = await import(
+              `${process.cwd()}/dist/storage/index.js`
+            );
+            const adapter = createStorageAdapter();
+
+            // 配送実行
+            const results = { uploaded: [], skipped: [], failed: [] };
+            for (const file of files) {
+              try {
+                const content = fs.readFileSync(file);
+                const result = await adapter.uploadFile(file, content, { overwrite });
+                results[result.status].push(file);
+                core.info(`${result.status === 'uploaded' ? '✅' : '⏭️'} ${file} → ${result.status}`);
+              } catch (err) {
+                results.failed.push(file);
+                core.error(`❌ ${file} → ${err.message}`);
+              }
+            }
+
+            // サマリー出力
+            core.info('');
+            core.info('=== 配送結果 ===');
+            core.info(`アップロード: ${results.uploaded.length}`);
+            core.info(`スキップ: ${results.skipped.length}`);
+            core.info(`エラー: ${results.failed.length}`);
+
+            if (results.failed.length > 0) {
+              core.setFailed(`${results.failed.length} ファイルの配送に失敗しました`);
+            }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ upstream merge の方向: **本リポジトリ → blog-drafts**
 ## コマンド
 
 ```bash
+npm run build         # TypeScript ビルド（dist/ に出力）
 npm run build:check   # TypeScript 型チェック（noEmit）
 npm run format        # Prettier + ESLint --fix + markdownlint --fix
 npm run format:check  # Prettier チェックのみ
@@ -48,12 +49,13 @@ mdpub-wpblocks (WordPress 投稿)
 ```text
 src/
   storage/
-    adapter.ts       # StorageAdapter インターフェース / StorageBackend 型
+    adapter.ts       # StorageAdapter / UploadOptions / UploadResult 型定義
     factory.ts       # createStorageAdapter() ファクトリ関数
-    dropbox.ts       # Dropbox 実装（スタブ）
+    dropbox.ts       # Dropbox 実装
     gdrive.ts        # Google Drive 実装（スタブ）
     index.ts         # re-export
-.github/workflows/   # GitHub Actions ワークフロー（実装予定）
+.github/workflows/
+  deliver.yml        # 記事配送ワークフロー
 ```
 
 ## 規約

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "type": "module",
     "private": true,
     "scripts": {
+        "build": "tsc -p tsconfig.build.json",
         "build:check": "tsc --noEmit",
         "format": "prettier --write \"**/*.{ts,json,md}\" && eslint --fix \"src/**/*.ts\" && markdownlint-cli2 --fix \"**/*.md\" \"#node_modules\"",
         "format:check": "prettier --check \"**/*.{ts,json,md}\"",

--- a/src/storage/adapter.ts
+++ b/src/storage/adapter.ts
@@ -1,3 +1,15 @@
+/** uploadFile() のオプション */
+export interface UploadOptions {
+    /** 既存ファイルを上書きするか（デフォルト: false） */
+    overwrite?: boolean;
+}
+
+/** uploadFile() の結果 */
+export interface UploadResult {
+    /** `'uploaded'`: アップロード成功、`'skipped'`: 既存ファイルがあるためスキップ */
+    status: 'uploaded' | 'skipped';
+}
+
 /**
  * クラウドストレージへのファイル配送を抽象化するインターフェース。
  * Dropbox / Google Drive 等のバックエンドを差し替え可能にする。
@@ -7,8 +19,13 @@ export interface StorageAdapter {
      * ファイルをストレージにアップロードする。
      * @param path - アップロード先のパス（例: `blog/posts/my-slug/index.md`）
      * @param content - ファイル内容
+     * @param options - アップロードオプション
      */
-    uploadFile(path: string, content: Buffer): Promise<void>;
+    uploadFile(
+        path: string,
+        content: Buffer,
+        options?: UploadOptions,
+    ): Promise<UploadResult>;
 
     /**
      * ストレージ上のファイルを削除する。

--- a/src/storage/gdrive.ts
+++ b/src/storage/gdrive.ts
@@ -1,8 +1,12 @@
-import type { StorageAdapter } from './adapter.js';
+import type { StorageAdapter, UploadOptions, UploadResult } from './adapter.js';
 
 /** Google Drive バックエンドの StorageAdapter 実装（未実装スタブ） */
 export class GDriveAdapter implements StorageAdapter {
-    uploadFile(_path: string, _content: Buffer): Promise<void> {
+    uploadFile(
+        _path: string,
+        _content: Buffer,
+        _options?: UploadOptions,
+    ): Promise<UploadResult> {
         throw new Error('GDriveAdapter.uploadFile は未実装です');
     }
 

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,2 +1,7 @@
-export type { StorageAdapter, StorageBackend } from './adapter.js';
+export type {
+    StorageAdapter,
+    StorageBackend,
+    UploadOptions,
+    UploadResult,
+} from './adapter.js';
 export { createStorageAdapter } from './factory.js';

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": false,
+        "outDir": "dist",
+        "declaration": true
+    },
+    "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## 概要

Issue #4 の実装。`posts/` 配下への push 時に StorageAdapter 経由でクラウドストレージへ自動配送する GitHub Actions ワークフローと、`uploadFile()` の上書き制御を追加する。

## 変更内容

### StorageAdapter インターフェース拡張

- `UploadOptions`（`overwrite?: boolean`）と `UploadResult`（`status: 'uploaded' | 'skipped'`）型を追加
- `uploadFile()` の戻り値を `Promise<void>` から `Promise<UploadResult>` に変更

### DropboxAdapter 上書き制御

- `overwrite: false`（デフォルト）: Dropbox API `mode: add` で送信。既存ファイルと衝突（409 `path/conflict`）した場合はエラーにせず `{ status: 'skipped' }` を返す
- `overwrite: true`: `mode: overwrite` で上書き、`{ status: 'uploaded' }` を返す

### GitHub Actions ワークフロー（`.github/workflows/deliver.yml`）

- **push トリガー**: `posts/**` への変更を `github.event.commits` から検出し `uploadFile(overwrite: false)` で配送。`.delivery-status.json` はパスフィルタで除外
- **workflow_dispatch**: `slug` と `overwrite` を入力として手動配送

### ビルド設定

- `tsconfig.build.json` を追加し `npm run build` で `dist/` に JS 出力
- ワークフロー内で `dist/storage/index.js` を動的 import して StorageAdapter を利用

## 受け入れ条件の確認

- [x] `DropboxAdapter.uploadFile()` が `overwrite` オプションを受け付ける
- [x] `overwrite: false` で既存ファイルがある場合、上書きせずにスキップ結果を返す
- [x] `overwrite: true` で既存ファイルを上書きする
- [x] `StorageAdapter` インターフェースに `overwrite` オプションが定義されている
- [x] `posts/` 配下への push で Actions が発火する
- [x] `posts/**/.delivery-status.json` の変更では Actions が発火しない
- [x] `github.event.commits` から変更ファイルが正しく抽出される
- [x] `workflow_dispatch` の `slug` input で対象記事を指定できる
- [x] `workflow_dispatch` の `overwrite` input で明示的に上書き配送できる

## テスト

vitest 16 件全通過（overwrite 関連 5 件追加）。

Closes #4